### PR TITLE
[fix] Add 'type' to 'repository' in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.2",
   "author": "Jarrett Cruger <jcrugzz@gmail.com>",
   "repository": {
+    "type": "git",
     "url": "git://github.com/jcrugzz/binary-pack.git"
   },
   "main": "index.js",


### PR DESCRIPTION
To comply with the Node.js standard.
