### PR TITLE
Fix npm engine warning on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "index.js",
   "engines": {
-    "node": "0.10.x || 0.8.x"
+    "node": ">=0.8.0"
   },
   "dependencies": {
     "binarypack": "0.0.4"


### PR DESCRIPTION
This silences the annoying npm engine warning (`npm WARN engine binary-pack@0.0.2: wanted: {"node":"0.10.x || 0.8.x"} (current: {"node":"0.12.0","npm":"2.5.0"})`).